### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Example for Linux crontab (`crontab -e`):
 Setting up own cron jobs is as simple as tagging services for your existing Symfony Commands.
 
 The tag takes the following arguments:
-- `name`: `ezplatform.cron.job`
+- `name`: `ibexa.cron.job`
 - `schedule`: _Takes any kind of [format supported by cron/cron](https://github.com/Cron/Cron#crontab-syntax), which mimics linux crontab format. E.g. `* * * * *`_
 - `category`: _(Optional, by default: `default`) Lets you separate cronjobs that should be run under different logic then default, e.g. infrequent jobs (NOTE: Means end user will need to setup several entries in his crontab to run all categories!)_
 - `options`: _(Optional, by default: `''`) Takes custom option/s in string format which are added to the command. (E.g. '--keep=0 --status=draft' for running the cleanup versions command)_
@@ -37,7 +37,7 @@ The tag takes the following arguments:
         class: EzSystems\DateBasedPublisherBundle\Command\PublishScheduledCommand
         tags:
             - { name: console.command }
-            - { name: ezplatform.cron.job, schedule: '* * * * *' }
+            - { name: ibexa.cron.job, schedule: '* * * * *' }
 ```
 
 ## Logging run command

--- a/src/bundle/DependencyInjection/Compiler/CronJobCompilerPass.php
+++ b/src/bundle/DependencyInjection/Compiler/CronJobCompilerPass.php
@@ -25,7 +25,7 @@ class CronJobCompilerPass implements CompilerPassInterface
         }
 
         $registry = $container->findDefinition('ezplatform.cron.registry.cronjobs');
-        $cronJobs = $container->findTaggedServiceIds('ezplatform.cron.job');
+        $cronJobs = $container->findTaggedServiceIds('ibexa.cron.job');
 
         foreach ($cronJobs as $id => $tags) {
             foreach ($tags as $cronJob) {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Asked for a review
