### PR TITLE
IBX-8119: Upgraded minimum PHP version to 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,20 +23,19 @@
         }
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": " >=8.3",
         "cron/cron": "^1.4",
+        "ibexa/core": "~5.0.x-dev",
+        "symfony/config": "^5.0",
+        "symfony/console": "^5.0",
         "symfony/dependency-injection": "^5.0",
         "symfony/http-kernel": "^5.0",
-        "symfony/console": "^5.0",
-        "symfony/config": "^5.0",
-        "symfony/process": "^5.0",
-        "ibexa/core": "~5.0.0@dev"
+        "symfony/process": "^5.0"
     },
     "require-dev": {
-        "ibexa/code-style": "^1.0",
-        "ibexa/doctrine-schema": "~5.0.0@dev",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "phpunit/phpunit": "^6.4 || ^7.0"
+        "ibexa/code-style": "^1.0",
+        "ibexa/doctrine-schema": "~5.0.x-dev"
     },
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots"
@@ -45,5 +44,8 @@
         "branch-alias": {
             "dev-main": "5.0.x-dev"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|

#### Description:

This PR bumps the minimum required version of PHP to 8.3.
`>=8.3` version constraint is set with expectation of compatibility with version PHP 9.

Additionally, this PR:
 * enforces sorting of packages within `require` and `require-dev` sections of composer.json file
 * replaces `~5.0.0@dev` declarations with their more development friendly `~5.0.x-dev`.
 * adjusts github workflows to match new PHP version
 * updates GH action versions

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!--
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes)
-->
