### PR TITLE
IBX-8139: Dropped class_alias BC layer statements from all classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,13 @@
         "psr-4": {
             "Ibexa\\Cron\\": "src/lib/",
             "Ibexa\\Bundle\\Cron\\": "src/bundle/",
-            "Ibexa\\Contracts\\Cron\\": "src/contracts/",
-            "EzSystems\\EzPlatformCronBundle\\": "src/bundle"
+            "Ibexa\\Contracts\\Cron\\": "src/contracts/"
         }
     },
     "autoload-dev": {
         "psr-4": {
             "Ibexa\\Tests\\Bundle\\Cron\\": "tests/bundle/",
-            "Ibexa\\Tests\\Cron\\": "tests/lib/",
-            "EzSystems\\EzPlatformCronBundle\\Tests\\": "tests/CronBundle"
+            "Ibexa\\Tests\\Cron\\": "tests/lib/"
         }
     },
     "require": {

--- a/src/bundle/Command/CronRunCommand.php
+++ b/src/bundle/Command/CronRunCommand.php
@@ -109,5 +109,3 @@ EOT
         return ['ezplatform:cron:run'];
     }
 }
-
-class_alias(CronRunCommand::class, 'EzSystems\EzPlatformCronBundle\Command\CronRunCommand');

--- a/src/bundle/DependencyInjection/Compiler/CronJobCompilerPass.php
+++ b/src/bundle/DependencyInjection/Compiler/CronJobCompilerPass.php
@@ -50,5 +50,3 @@ class CronJobCompilerPass implements CompilerPassInterface
         }
     }
 }
-
-class_alias(CronJobCompilerPass::class, 'EzSystems\EzPlatformCronBundle\DependencyInjection\Compiler\CronJobCompilerPass');

--- a/src/bundle/DependencyInjection/IbexaCronExtension.php
+++ b/src/bundle/DependencyInjection/IbexaCronExtension.php
@@ -39,5 +39,3 @@ class IbexaCronExtension extends Extension implements PrependExtensionInterface
         $container->prependExtensionConfig('monolog', $config);
     }
 }
-
-class_alias(IbexaCronExtension::class, 'EzSystems\EzPlatformCronBundle\DependencyInjection\EzPlatformCronExtension');

--- a/src/bundle/IbexaCronBundle.php
+++ b/src/bundle/IbexaCronBundle.php
@@ -20,5 +20,3 @@ class IbexaCronBundle extends Bundle
         $container->addCompilerPass(new CronJobCompilerPass());
     }
 }
-
-class_alias(IbexaCronBundle::class, 'EzSystems\EzPlatformCronBundle\EzPlatformCronBundle');

--- a/src/bundle/Registry/CronJobsRegistry.php
+++ b/src/bundle/Registry/CronJobsRegistry.php
@@ -82,5 +82,3 @@ class CronJobsRegistry
         return $this->cronJobs[$category];
     }
 }
-
-class_alias(CronJobsRegistry::class, 'EzSystems\EzPlatformCronBundle\Registry\CronJobsRegistry');


### PR DESCRIPTION
| :ticket: Issue | IBX-8139 |
|----------------|-----------|

#### Description:

Dropped `class_alias` BC layer statements from all classes using https://github.com/ibexa/rector/pull/2

#### For QA:

No QA needed

#### Documentation:

Document that our BC layer has been dropped
